### PR TITLE
【bugfix】CSV形式のログについて

### DIFF
--- a/wp-plugin-confirm.php
+++ b/wp-plugin-confirm.php
@@ -114,7 +114,7 @@ class WP_Plugin_Confirm {
 	public function add_access_restrictions() {
 		$url = $_SERVER["REQUEST_URI"];
 		if ( strpos( $url, 'wp-plugin-confirm/logs' ) ) {
-			wp_redirect( admin_url() );
+			wp_redirect( home_url() );
 			exit;
 		}
 	}


### PR DESCRIPTION
#1 
脆弱性対応
> クエリパラメータに action と plugin が存在したらどのページであってもCSVに書き出される
しかも値がそのまま書き込まれる。しかも値がそのまま書き込まれる。
> <script> タグで囲まれたJavascriptコードをクエリパラメータに入れるとダッシュボードで実行されてしまいます。

・プラグインページのみログの書き込みを行うようにする
・エスケープ関数を追加
・カッコが含まれていた場合、ログの書き込みを行わないようにする

> ブラウザから <サーバーのドメイン>/wp-content/plugins/wp-plugin-confirm/logs/yyyy-mm.csv にアクセスするとファイルが閲覧できてしまう

~~・home_urlにリダイレクトされるようにする~~
対処法が無いか調査中